### PR TITLE
Print pulled entity to stdout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.redhat.lightblue.client</groupId>
 			<artifactId>lightblue-client-http</artifactId>
-			<version>5.7.0-SNAPSHOT</version>
+			<version>5.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>

--- a/src/main/scala/com/redhat/lightblue/metadata/MetadataManagerCli.scala
+++ b/src/main/scala/com/redhat/lightblue/metadata/MetadataManagerCli.scala
@@ -257,7 +257,8 @@ class MetadataManagerCli(args: Array[String], _client: scala.Option[LightblueCli
                         if (remoteEntities.size == 1 && cmd.hasOption("c")) {
                             println(remoteEntity.text)
                         } else {
-                            logger.info(s"""Saving ${remoteEntity}...""")
+                            // TODO: should be logger.info, but that breaks the integration test
+                            println(s"""Saving ${remoteEntity}...""")
                             Files.write(Paths.get(s"""${remoteEntity.name}.json"""), remoteEntity.text.getBytes)
                         }
                     }

--- a/src/main/scala/com/redhat/lightblue/metadata/MetadataManagerCli.scala
+++ b/src/main/scala/com/redhat/lightblue/metadata/MetadataManagerCli.scala
@@ -104,6 +104,12 @@ class MetadataManagerCli(args: Array[String], _client: scala.Option[LightblueCli
             .hasArg()
             .build()
 
+        val stdoutOption = Option.builder("c")
+            .required(false)
+            .longOpt("stdout")
+            .desc("Send resuls to stdout. Will work only if you pull a single entity.")
+            .build()
+
         // options which apply to any operation
         options.addOption(helpOption)
 
@@ -126,6 +132,7 @@ class MetadataManagerCli(args: Array[String], _client: scala.Option[LightblueCli
                 options.addOption(entityOption)
                 options.addOption(versionOption)
                 options.addOption(pathOption)
+                options.addOption(stdoutOption)
             }
             case "push" => {
                 options.addOption(lbClientOption)
@@ -212,12 +219,20 @@ class MetadataManagerCli(args: Array[String], _client: scala.Option[LightblueCli
 
                         val updatedLocalEntity = localEntity.replacePath(path, remoteEntity)
 
-                        println(s"""Saving $path to ${updatedLocalEntity.name}.json...""")
-                        Files.write(Paths.get(s"""${updatedLocalEntity.name}.json"""), updatedLocalEntity.text.getBytes)
+                        if (remoteEntities.size == 1 && cmd.hasOption("c")) {
+                            println(updatedLocalEntity.text)
+                        } else {
+                            logger.info(s"""Saving $path to ${updatedLocalEntity.name}.json...""")
+                            Files.write(Paths.get(s"""${updatedLocalEntity.name}.json"""), updatedLocalEntity.text.getBytes)
+                        }
                     } else {
                         // download metadata from Lightblue and save it locally
-                        println(s"""Saving ${remoteEntity}...""")
-                        Files.write(Paths.get(s"""${remoteEntity.name}.json"""), remoteEntity.text.getBytes)
+                        if (remoteEntities.size == 1 && cmd.hasOption("c")) {
+                            println(remoteEntity.text)
+                        } else {
+                            logger.info(s"""Saving ${remoteEntity}...""")
+                            Files.write(Paths.get(s"""${remoteEntity.name}.json"""), remoteEntity.text.getBytes)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Lbmd cli is modeled after git, so lbmd pull works on local files (and can affect multiple). However, it's sometimes convenient to be able to send lbmd pull output to stdout and pipe it to other json utilities.

https://github.com/lightblue-platform/lightblue-metadata-manager/issues/15